### PR TITLE
com.palm.mediapermission: Migrate to Enhanced ACG

### DIFF
--- a/files/sysbus/com.palm.mediapermissions.api.json
+++ b/files/sysbus/com.palm.mediapermissions.api.json
@@ -1,5 +1,5 @@
 {
-    "services": [
+    "mediapermissions-service.operation": [
         "com.palm.mediapermissions/request",
         "com.palm.mediapermissions/permissionsResponse"
     ]

--- a/files/sysbus/com.palm.mediapermissions.perm.json
+++ b/files/sysbus/com.palm.mediapermissions.perm.json
@@ -1,8 +1,6 @@
 {
     "com.palm.mediapermissions": [
-        "applications",
-        "services",
-        "database",
-        "database.internal"
+        "mediapermissions-service.operation",
+        "database.operation"
     ]
 }

--- a/files/sysbus/com.palm.mediapermissions.role.json
+++ b/files/sysbus/com.palm.mediapermissions.role.json
@@ -1,6 +1,7 @@
 {
     "appId": "com.palm.mediapermissions",
     "allowedNames": ["com.palm.mediapermissions"],
+    "trustLevel": "oem",
     "type": "regular",
     "permissions": [
         {


### PR DESCRIPTION
In order to be able to use latest components from upstream webOS OSE.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
